### PR TITLE
About page: simple text fixes

### DIFF
--- a/about.md
+++ b/about.md
@@ -5,9 +5,9 @@ permalink: /about/
 ---
 
 MyPaint began in 2004 when Martin Renold bought himself a Wacom 
-graphics tablet.He noticed that the [program][gimp] he was using would 
+graphics tablet. He noticed that the [program][gimp] he was using would 
 sometimes drop a stroke when scribbling too fast. He thought he could 
-be more expressiveif his brush reacted in a different way to pressure 
+be more expressive if his brush reacted in a different way to pressure 
 and speed.
 
 ![mypaint-ss-1]
@@ -21,7 +21,7 @@ that Martin also wanted, so development continued. Since then, many
 more have contributed to the code, or spread the word about MyPaint on 
 the Internet.
 
-Fast-Forward to today. MyPaint is a nimble, distraction-free, and easy 
+Fast-forward to today. MyPaint is a nimble, distraction-free, and easy 
 tool for digital painters. It supports graphics tablets made by Wacom, 
 and many similar devices. Its brush engine is versatile and 
 configurable, and it provides useful, productive tools.
@@ -32,7 +32,7 @@ the standard ones. It’s easy to make expressive, artful new brushes
 that don’t respond like anything conventional.
 
 Fullscreen mode declutters the interface, leaving you with just your 
-brush and your creativity. You can still reveal the tools you want, 
+brush and your creativity. You can still reveal the tools you want, 
 when you need them. This distraction-free approach means you can focus 
 better on the art you make, not the tool you make it with.
 


### PR DESCRIPTION
1. Missing space
2. Missing space
3. Capital letter in the middle of the sentence
4. Extra space (because of non-breaking space)
